### PR TITLE
fix: stern install

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -97,7 +97,9 @@ runs:
       run: |
         mkdir ${GITHUB_WORKSPACE}/stern
         cd ${GITHUB_WORKSPACE}/stern
-        wget -q https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64
+        wget -q https://github.com/stern/stern/releases/download/v1.22.0/stern_1.22.0_linux_amd64.tar.gz
+        tar xzvf stern_1.22.0_linux_amd64.tar.gz
+        rm stern_1.22.0_linux_amd64.tar.gz LICENSE
         mv stern_linux_amd64 stern
         chmod +x stern
         echo "${GITHUB_WORKSPACE}/stern" >> $GITHUB_PATH


### PR DESCRIPTION
1.11.0 doesn't exist in github releases anymore. this upgrades to 1.22 and fixes the installation